### PR TITLE
Fix getgit parentheses

### DIFF
--- a/backup-github.sh
+++ b/backup-github.sh
@@ -177,7 +177,7 @@ function GITCMD {
 
 # The function `getgit` will clone (or update) specified repo ($1, without
 # a `.git` suffix) into specified directory ($2)
-function getgit (
+function getgit() (
     # Sub-shelled to constrain "export" visibility of credentials
     local REPOURI="$1"
     local DIRNAME="$2"


### PR DESCRIPTION
Bash complained with

```
./backup_github.sh: line 181: syntax error near unexpected token `newline'
./backup_github.sh: line 181: `function getgit ('
```